### PR TITLE
Refactored the addresses and read me from xenonym to iridium

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Putting network logs on a blockchain
 2) To run, cd into the main directory and type `docker-compose build && docker-compose up`
 
 # Network addresses
-- syslog-ng: `xenonym_syslog_1:601`/`localhost:601`
-- Elasticsearch: `xenonym_elastic_1:9200`/`localhost:9200`
-- Kibana: `xenonym_elastic_1:5601`/`localhost:5601`
+- syslog-ng: `iridium_syslog_1:601`/`localhost:601`
+- Elasticsearch: `iridium_elastic_1:9200`/`localhost:9200`
+- Kibana: `iridium_elastic_1:5601`/`localhost:5601`

--- a/syslog/syslog-ng.conf
+++ b/syslog/syslog-ng.conf
@@ -11,7 +11,7 @@ source s_net {
 destination d_elastic {
   elasticsearch2 (
     cluster("elasticsearch")
-    cluster-url("http://xenonym_elastic_1:9200")
+    cluster-url("http://iridium_elastic_1:9200")
     client_mode("http")
     index("syslog-ng-${YEAR}.${MONTH}.${DAY}")
     type("_doc")


### PR DESCRIPTION
I don't see where the syslog-ng address is configured as per the read me (line 8). Where is the config code that instructs the address to be -- syslog-ng: `xenonym_syslog_1:601`/`localhost:601`?