### PR TITLE
Complete basic logging from nginx to syslog-ng

### DIFF
--- a/client/entrypoint.sh
+++ b/client/entrypoint.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+
+sleep 20 # give Elasticsearch time to start up
 while true
 do 
   curl --silent server:80 > dev/null

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx
 RUN apt-get update \
-    && apt-get install -y syslog-ng
+    && apt-get install -y syslog-ng-core
 COPY syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
 COPY nginx.conf /etc/nginx/nginx.conf
 # CMD ["/etc/init.d/syslog-ng", "restart"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,4 +3,6 @@ RUN apt-get update \
     && apt-get install -y syslog-ng-core
 COPY syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
 COPY nginx.conf /etc/nginx/nginx.conf
-# CMD ["/etc/init.d/syslog-ng", "restart"]
+COPY entrypoint.sh /entrypoint.sh
+EXPOSE 80
+CMD [ "bash", "/entrypoint.sh" ]

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+/etc/init.d/syslog-ng restart
+nginx -g "daemon off;"

--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -2,6 +2,7 @@ user  nginx;
 worker_processes  1;
 
 error_log  /var/log/nginx/error.log warn;
+error_log  syslog:server=unix:/var/log/nginx.sock warn;
 pid        /var/run/nginx.pid;
 
 
@@ -19,7 +20,7 @@ http {
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
     access_log  /var/log/nginx/access.log main;
-    access_log  /var/log/nginx/access_syslog.log main;
+    access_log  syslog:server=unix:/var/log/nginx.sock main;
 
     sendfile        on;
     #tcp_nopush     on;

--- a/server/syslog-ng.conf
+++ b/server/syslog-ng.conf
@@ -1,15 +1,15 @@
 @version: 3.8
 @include "scl.conf"
 
-source s_access_tail { 
-  file("/var/log/nginx/access_syslog.log" follow-freq(1) flags(no-parse)); 
+source s_nginx { 
+	unix-dgram("/var/log/nginx.sock" create-dirs(yes)); 
 };
 
-destination d_syslog_server { 
-  network("syslog"); 
+destination d_syslog { 
+  syslog("iridium_syslog_1" transport("tcp") port(601)); 
 };
 
 log {
-  source(s_access_tail);
-  destination(d_syslog_server);
+  source(s_nginx);
+  destination(d_syslog);
 };


### PR DESCRIPTION
- nginx now sends syslogs over Unix sockets to prevent file lock issues
- custom server entrypoint to start both nginx and syslog-ng