### PR TITLE
Use disk buffer before elastic server starts

### DIFF
--- a/client/entrypoint.sh
+++ b/client/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-sleep 20 # give Elasticsearch time to start up
 while true
 do 
   curl --silent server:80 > dev/null

--- a/syslog/syslog-ng.conf
+++ b/syslog/syslog-ng.conf
@@ -16,6 +16,11 @@ destination d_elastic {
     index("syslog-ng-${YEAR}.${MONTH}.${DAY}")
     type("_doc")
     template("$(format-json --scope rfc5424 --scope nv-pairs --exclude DATE --key ISODATE)")
+    disk-buffer(
+      mem-buf-size(10000)
+      disk-buf-size(2000000)
+      reliable(yes)
+    )
   )
 };
 


### PR DESCRIPTION
Notable syslog logs which show that the disk buffer is working: 

syslog_1   | [2018-03-16T09:58:06.617774] Registering candidate plugin; module='disk-buffer', context='inner-dest', name='disk_buffer'

syslog_1   | [2018-03-16T09:58:06.864418] Module loaded and initialized successfully; module='disk-buffer'

syslog_1   | [2018-03-16T09:58:13.379230] Reliable disk-buffer state saved; filename='/var/lib/syslog-ng/syslog-ng-00000.rqf', qdisk_length='0'